### PR TITLE
fix csv entries that have values that have commas in it break the csv parsing

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -146,6 +146,9 @@ func parseDate(col string) (time.Time, bool) {
 }
 
 func parseCurrency(col string) (float64, bool) {
+	//strip out any commas that are here.  
+	//Yes, this is English British centric, extend as needed
+	col = strings.Replace(col, ",", "", -1)
 	f, err := strconv.ParseFloat(col, 64)
 	return f, err == nil
 }

--- a/test.csv
+++ b/test.csv
@@ -1,1 +1,2 @@
 "12/13/2015","Description","-50"
+"07/08/2023","Value has comma in it","-1,500"


### PR DESCRIPTION
prior to this fix if you're csv has an amount that has a comma in it, the csv parser fails to recognize it as a number since the value doesn't conform to the goland float standard see https://go.dev/ref/spec#Floating-point_literals